### PR TITLE
rtc: better format the function to get RTC time in microsecond

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,33 @@
+name: checkpatch
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  checkpatch:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Download Checkpatch files from Zephyr RTOS
+      shell: bash
+      run: |
+        wget https://github.com/zephyrproject-rtos/zephyr/raw/main/scripts/checkpatch.pl -O ./checkpatch.pl
+        chmod +x ./checkpatch.pl
+        wget https://github.com/zephyrproject-rtos/zephyr/raw/main/.checkpatch.conf -O ./.checkpatch.conf
+        wget https://github.com/zephyrproject-rtos/zephyr/raw/main/scripts/spelling.txt -O ./spelling.txt
+        echo "--ignore PREFER_ALIGNED" >> ./.checkpatch.conf
+        echo "--ignore NEW_TYPEDEFS" >> ./.checkpatch.conf
+
+    - name: Set Git Base
+      shell: bash
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        echo "checkpatch base is: $(git show FETCH_HEAD --oneline --raw)"
+
+    - name: Run Checkpath
+      shell: bash
+      run: |
+        git diff --patch FETCH_HEAD | ./checkpatch.pl --no-tree --codespellfile ./spelling.txt -

--- a/bsp_sedi/drivers/rtc/sedi_rtc.c
+++ b/bsp_sedi/drivers/rtc/sedi_rtc.c
@@ -48,7 +48,6 @@ int sedi_rtc_get_capabilities(sedi_rtc_capabilities_t *cap)
 
 int sedi_rtc_init(void)
 {
-	/* SEDI RTC have no alarm and interrupt feature, callback not used */
 	return SEDI_DRIVER_OK;
 }
 
@@ -77,12 +76,8 @@ uint64_t sedi_rtc_get(void)
 	return ((uint64_t)upper << 32U) | lower;
 }
 
-void sedi_rtc_get_us(INOUT uint64_t *us)
+uint64_t sedi_rtc_get_us (void)
 {
-	/* returns the current time in micro seconds. */
-	uint64_t result;
 	uint64_t rtc = sedi_rtc_get();
-
-	result = sedi_rtc_to_us(rtc);
-	*us = result;
+	return sedi_rtc_to_us(rtc);
 }

--- a/bsp_sedi/include/driver/sedi_driver_rtc.h
+++ b/bsp_sedi/include/driver/sedi_driver_rtc.h
@@ -102,11 +102,10 @@ int sedi_rtc_set_power(IN sedi_power_state_t state);
 uint64_t sedi_rtc_get(void);
 
 /*!
- * \brief Get rtc timer in us
- * \param[INOUT] us: Time in us units.
- * \return Time of rtc in us.
+ * \brief Get rtc time in microsecond
+ * \return RTC time in microsecond
  */
-void sedi_rtc_get_us(INOUT uint64_t *us);
+uint64_t sedi_rtc_get_us(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
return as function return value instead of in out parameter